### PR TITLE
Add Gold + WTI markets via Hyperliquid xyz dex

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -33,15 +33,22 @@ MAX_LEVERAGE = 20              # max leverage allowed
 LOOKBACK_BARS = 500            # history buffer provided to strategy
 BAR_INTERVAL = "1h"
 
-SYMBOLS = ["BTC", "ETH", "SOL"]
+SYMBOLS = ["BTC", "ETH", "SOL", "GOLD", "OIL"]
 
-# Date splits (UTC timestamps)
-TRAIN_START = "2023-06-01"
-TRAIN_END = "2024-06-30"
-VAL_START = "2024-07-01"
-VAL_END = "2025-03-31"
-TEST_START = "2025-04-01"
-TEST_END = "2025-12-31"
+# HIP-3 builder-dex markets: repo symbol -> Hyperliquid dex-prefixed coin.
+# These commodities are not on CryptoCompare; their candles + funding come
+# from the Hyperliquid `xyz` perp dex (xyz:CL is WTI crude).
+HL_DEX_COINS = {"GOLD": "xyz:GOLD", "OIL": "xyz:CL"}
+
+# Date splits (UTC timestamps). Shifted to a recent window: the GOLD/OIL perps
+# on the xyz dex only have history from late 2025 onward (xyz:CL starts
+# 2026-01-06), so all five markets are evaluated over a common 2026 window.
+TRAIN_START = "2026-01-06"
+TRAIN_END = "2026-03-10"
+VAL_START = "2026-03-10"
+VAL_END = "2026-04-25"
+TEST_START = "2026-04-25"
+TEST_END = "2026-05-18"
 
 HOURS_PER_YEAR = 8760
 
@@ -233,21 +240,27 @@ def download_data(symbols=None):
             print(f"  {symbol}: already have {len(existing)} bars")
             continue
 
-        print(f"  {symbol}: downloading candles from CryptoCompare...")
-
-        # Use CryptoCompare for reliable historical OHLCV (no geo-restrictions)
-        df = _download_cryptocompare_candles(symbol, start_ms, end_ms)
-        if len(df) < 100:
-            print(f"  {symbol}: CryptoCompare insufficient ({len(df)} bars), trying HL...")
-            df = _download_hl_candles(symbol, "1h", start_ms, end_ms)
+        # Commodities (GOLD/OIL) live on the Hyperliquid xyz HIP-3 dex and are
+        # not on CryptoCompare; route them straight to the HL candle endpoint.
+        if symbol in HL_DEX_COINS:
+            hl_coin = HL_DEX_COINS[symbol]
+            print(f"  {symbol}: downloading {hl_coin} candles from Hyperliquid xyz dex...")
+            df = _download_hl_candles(hl_coin, "1h", start_ms, end_ms)
+        else:
+            print(f"  {symbol}: downloading candles from CryptoCompare...")
+            # Use CryptoCompare for reliable historical OHLCV (no geo-restrictions)
+            df = _download_cryptocompare_candles(symbol, start_ms, end_ms)
+            if len(df) < 100:
+                print(f"  {symbol}: CryptoCompare insufficient ({len(df)} bars), trying HL...")
+                df = _download_hl_candles(symbol, "1h", start_ms, end_ms)
 
         if df.empty:
             print(f"  {symbol}: NO DATA AVAILABLE, skipping")
             continue
 
-        # Download funding rates
+        # Download funding rates (dex-prefixed coin for HIP-3 markets)
         print(f"  {symbol}: downloading funding rates...")
-        funding = _download_hl_funding(symbol, start_ms, end_ms)
+        funding = _download_hl_funding(HL_DEX_COINS.get(symbol, symbol), start_ms, end_ms)
 
         # Merge
         df = df.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)

--- a/strategy.py
+++ b/strategy.py
@@ -10,8 +10,8 @@ Changes from exp28 (ATR 5.5, score 9.382):
 import numpy as np
 from prepare import Signal, PortfolioState, BarData
 
-ACTIVE_SYMBOLS = ["BTC", "ETH", "SOL"]
-SYMBOL_WEIGHTS = {"BTC": 0.33, "ETH": 0.33, "SOL": 0.33}
+ACTIVE_SYMBOLS = ["BTC", "ETH", "SOL", "GOLD", "OIL"]
+SYMBOL_WEIGHTS = {"BTC": 0.2, "ETH": 0.2, "SOL": 0.2, "GOLD": 0.2, "OIL": 0.2}
 
 SHORT_WINDOW = 6
 MED_WINDOW = 12


### PR DESCRIPTION
## Summary

Points the autoresearch backtest harness at two commodity perps — **Gold** and **WTI crude** — alongside the existing BTC/ETH/SOL crypto universe.

## Changes

- **`prepare.py`**
  - `SYMBOLS` → `["BTC", "ETH", "SOL", "GOLD", "OIL"]`
  - New `HL_DEX_COINS` map routes `GOLD`/`OIL` to the Hyperliquid `xyz` HIP-3 dex (`xyz:GOLD`, `xyz:CL` = WTI crude)
  - `download_data` fetches commodity candles **and** funding from the HL `xyz` dex; crypto keeps the CryptoCompare → HL fallback path
  - Eval window shifted to a recent 2026 span (TRAIN/VAL/TEST: Jan 6 → Mar 10 → Apr 25 → May 18)
- **`strategy.py`**: `ACTIVE_SYMBOLS` / `SYMBOL_WEIGHTS` extended to all 5 markets (universe declaration only — no strategy-logic changes)

## Why the window moved

The `xyz` commodity perps are new — Hyperliquid only has hourly history from **2025-12-22** (`xyz:GOLD`) and **2026-01-06** (`xyz:CL`). The previous 2024-2025 eval window predates both, and there is no deep commodity history available anywhere (CryptoCompare has no oil/gold coverage). So all five markets are now evaluated over a common 2026 window. Crypto is re-baselined on recent data; the prior 103-experiment scores remain in `STRATEGIES.md` / `results.tsv` as history.

## Verification

| Check | Result |
|---|---|
| Data download | All 5 markets — GOLD/OIL fetched from HL `xyz` dex (3169 / 3155 bars) |
| `backtest.py` | score 22.23, 2209 trades, max DD 0.11%, no crash/timeout |
| GOLD/OIL VAL data | 1104 bars each, real prices (GOLD $4210–5227, OIL $79.65–115.56), funding present |
| GOLD/OIL traded | 388 / 451 signals emitted — comparable to BTC 440 / ETH 472 / SOL 458 |

## Follow-up

The `/autoresearch` loop has not run on the new universe yet — it would now evolve commodity-aware strategy logic across all 5 markets. The current `strategy.py` carries crypto-tuned heuristics (BTC-correlation filter, etc.) left intentionally untouched in this PR.
